### PR TITLE
added Guzzle options to prevent PHP fatal error

### DIFF
--- a/src/FcmClient.php
+++ b/src/FcmClient.php
@@ -58,8 +58,14 @@ class FcmClient
      *
      * @return array
      */
-    public function send(Request $request): array
+    public function send(Request $request, array $arguments): array
     {
+        $default = [
+            'json' => $request->getBody(),
+            'http_errors' => false
+        ];
+
+        $options = is_array($arguments) && isset($arguments) ? $arguments : $default;
         // Build guzzle api client.
         $client = $this->getGuzzleClient();
 
@@ -67,9 +73,7 @@ class FcmClient
         $url = $request->getUrl();
 
         // Create and send the request.
-        $response = $client->post($url, [
-            'json' => $request->getBody()
-        ]);
+        $response = $client->post($url, $options);
 
         // Decode the response body from json to a plain php array.
         $body = json_decode($response->getBody()->getContents(), true);


### PR DESCRIPTION
### Description
NOT critical: Added Client options to pass on as an array to GuzzleHTTP client.

### Related issues
#2 
#19 

### Release Summary
- created second arguments for Fcm/Client send function.
- the argument is an array of options to be passed through GuzzleHTTPClient

### Checklist
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan
The client is still functional and does not produce additional errors.
