### PR TITLE
Add click_action for ionic FCM plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-**/.DS_Store
-/nbproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/.DS_Store
+/nbproject

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -241,7 +241,7 @@ class Notification implements Request
         }
 
         if (!empty($this->click_action)) {
-            $request['click_action'] = $this->click_action;
+            $request['notification']['click_action'] = $this->click_action;
         }
         
         if (!empty($this->data)) {

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -5,10 +5,10 @@ namespace Fcm\Push;
 use Fcm\Exception\NotificationException;
 use Fcm\Request;
 
-class Notification implements Request
-{
-    use Push ;
-    
+class Notification implements Request {
+
+    use Push;
+
     /**
      * @var string
      */
@@ -28,7 +28,7 @@ class Notification implements Request
      * @var string
      */
     private $icon;
-    
+
     /**
      * @var string
      */
@@ -37,8 +37,8 @@ class Notification implements Request
     /**
      * @var string
      */
-    private $tag;    
-    
+    private $tag;
+
     /**
      * @var string
      */
@@ -48,14 +48,18 @@ class Notification implements Request
      * @var int
      */
     private $badge;
-    
+
+    /**
+     * @var string
+     */
+    private $click_action;
+
     /**
      * @param string $title
      * @param string $body
      * @param string $recipient
      */
-    public function __construct(string $title = '', string $body = '', string $recipient = '', string $sound = '', string $icon = '', string $color = '', int $badge = 0, string $tag = '', string $subtitle = '', array $data = [])
-    {
+    public function __construct(string $title = '', string $body = '', string $recipient = '', string $sound = '', string $icon = '', string $color = '', int $badge = 0, string $tag = '', string $subtitle = '', array $data = [], string $click_action = '') {
         $this->title = $title;
         $this->body = $body;
         $this->sound = $sound;
@@ -64,11 +68,15 @@ class Notification implements Request
         $this->badge = $badge;
         $this->tag = $tag;
         $this->subtitle = $subtitle;
-        
+
+        if (!empty($click_action)) {
+            $this->click_action = $click_action;
+        }
+
         if (!empty($data)) {
             $this->data = $data;
-        } 
-        
+        }
+
         if (!empty($recipient)) {
             $this->addRecipient($recipient);
         }
@@ -79,8 +87,7 @@ class Notification implements Request
      *
      * @return $this
      */
-    public function setTitle(string $title): self
-    {
+    public function setTitle(string $title): self {
         $this->title = $title;
 
         return $this;
@@ -91,32 +98,29 @@ class Notification implements Request
      *
      * @return $this
      */
-    public function setBody(string $body): self
-    {
+    public function setBody(string $body): self {
         $this->body = $body;
 
         return $this;
     }
-    
+
     /**
      * @param string $sound
      *
      * @return $this
      */
-    public function setSound(string $sound): self
-    {
+    public function setSound(string $sound): self {
         $this->sound = $sound;
 
         return $this;
-    } 
-    
+    }
+
     /**
      * @param string $icon
      *
      * @return $this
      */
-    public function setIcon(string $icon): self
-    {
+    public function setIcon(string $icon): self {
         $this->icon = $icon;
 
         return $this;
@@ -127,32 +131,29 @@ class Notification implements Request
      *
      * @return $this
      */
-    public function setColor(string $color): self
-    {
+    public function setColor(string $color): self {
         $this->color = $color;
 
         return $this;
     }
-    
+
     /**
      * @param string badge
      *
      * @return $this
      */
-    public function setBadge(int $badge): self
-    {
+    public function setBadge(int $badge): self {
         $this->badge = $badge;
 
         return $this;
     }
-    
+
     /**
      * @param string $tag
      *
      * @return $this
      */
-    public function setTag(string $tag): self
-    {
+    public function setTag(string $tag): self {
         $this->tag = $tag;
 
         return $this;
@@ -163,9 +164,19 @@ class Notification implements Request
      *
      * @return $this
      */
-    public function setSubtitle(string $subtitle): self
-    {
+    public function setSubtitle(string $subtitle): self {
         $this->subtitle = $subtitle;
+
+        return $this;
+    }
+
+    /**
+     * @param string $click_action
+     *
+     * @return $this
+     */
+    public function setClickAction(string $click_action): self {
+        $this->click_action = $click_action;
 
         return $this;
     }
@@ -173,8 +184,7 @@ class Notification implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
-    {
+    public function getBody(): array {
         if (empty($this->recipients) && empty($this->topics)) {
             throw new NotificationException('Must minimaly specify a single recipient or topic.');
         }
@@ -183,10 +193,10 @@ class Notification implements Request
             throw new NotificationException('Must either specify a recipient or topic, not more then one.');
         }
         /*
-        if (empty($this->data)) {
-            throw new NotificationException('Data should not be empty for a Data Notification.');
-        }
-        */
+          if (empty($this->data)) {
+          throw new NotificationException('Data should not be empty for a Data Notification.');
+          }
+         */
         $request = [];
 
         if (!empty($this->recipients)) {
@@ -216,13 +226,18 @@ class Notification implements Request
         $request['notification']['color'] = $this->color;
         $request['notification']['tag'] = $this->tag;
         $request['notification']['subtitle'] = $this->subtitle;
-        if ($this->badge>0) {
+        if ($this->badge > 0) {
             $request['notification']['badge'] = $this->badge;
         }
-        
+
+        if (!empty($this->click_action)) {
+            $request['click_action'] = $this->click_action;
+        }
+
         if (!empty($this->data)) {
             $request['data'] = $this->data;
         }
-        return $request; 
+        return $request;
     }
+
 }

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -5,10 +5,10 @@ namespace Fcm\Push;
 use Fcm\Exception\NotificationException;
 use Fcm\Request;
 
-class Notification implements Request {
-
-    use Push;
-
+class Notification implements Request
+{
+    use Push ;
+    
     /**
      * @var string
      */
@@ -28,7 +28,7 @@ class Notification implements Request {
      * @var string
      */
     private $icon;
-
+    
     /**
      * @var string
      */
@@ -37,8 +37,8 @@ class Notification implements Request {
     /**
      * @var string
      */
-    private $tag;
-
+    private $tag;    
+    
     /**
      * @var string
      */
@@ -53,13 +53,14 @@ class Notification implements Request {
      * @var string
      */
     private $click_action;
-
+    
     /**
      * @param string $title
      * @param string $body
      * @param string $recipient
      */
-    public function __construct(string $title = '', string $body = '', string $recipient = '', string $sound = '', string $icon = '', string $color = '', int $badge = 0, string $tag = '', string $subtitle = '', array $data = [], string $click_action = '') {
+    public function __construct(string $title = '', string $body = '', string $recipient = '', string $sound = '', string $icon = '', string $color = '', int $badge = 0, string $tag = '', string $subtitle = '', array $data = [], string $click_action = '')
+    {
         $this->title = $title;
         $this->body = $body;
         $this->sound = $sound;
@@ -72,11 +73,11 @@ class Notification implements Request {
         if (!empty($click_action)) {
             $this->click_action = $click_action;
         }
-
+        
         if (!empty($data)) {
             $this->data = $data;
-        }
-
+        } 
+        
         if (!empty($recipient)) {
             $this->addRecipient($recipient);
         }
@@ -87,7 +88,8 @@ class Notification implements Request {
      *
      * @return $this
      */
-    public function setTitle(string $title): self {
+    public function setTitle(string $title): self
+    {
         $this->title = $title;
 
         return $this;
@@ -98,29 +100,32 @@ class Notification implements Request {
      *
      * @return $this
      */
-    public function setBody(string $body): self {
+    public function setBody(string $body): self
+    {
         $this->body = $body;
 
         return $this;
     }
-
+    
     /**
      * @param string $sound
      *
      * @return $this
      */
-    public function setSound(string $sound): self {
+    public function setSound(string $sound): self
+    {
         $this->sound = $sound;
 
         return $this;
-    }
-
+    } 
+    
     /**
      * @param string $icon
      *
      * @return $this
      */
-    public function setIcon(string $icon): self {
+    public function setIcon(string $icon): self
+    {
         $this->icon = $icon;
 
         return $this;
@@ -131,29 +136,32 @@ class Notification implements Request {
      *
      * @return $this
      */
-    public function setColor(string $color): self {
+    public function setColor(string $color): self
+    {
         $this->color = $color;
 
         return $this;
     }
-
+    
     /**
      * @param string badge
      *
      * @return $this
      */
-    public function setBadge(int $badge): self {
+    public function setBadge(int $badge): self
+    {
         $this->badge = $badge;
 
         return $this;
     }
-
+    
     /**
      * @param string $tag
      *
      * @return $this
      */
-    public function setTag(string $tag): self {
+    public function setTag(string $tag): self
+    {
         $this->tag = $tag;
 
         return $this;
@@ -164,7 +172,8 @@ class Notification implements Request {
      *
      * @return $this
      */
-    public function setSubtitle(string $subtitle): self {
+    public function setSubtitle(string $subtitle): self
+    {
         $this->subtitle = $subtitle;
 
         return $this;
@@ -184,7 +193,8 @@ class Notification implements Request {
     /**
      * @inheritdoc
      */
-    public function getBody(): array {
+    public function getBody(): array
+    {
         if (empty($this->recipients) && empty($this->topics)) {
             throw new NotificationException('Must minimaly specify a single recipient or topic.');
         }
@@ -193,10 +203,10 @@ class Notification implements Request {
             throw new NotificationException('Must either specify a recipient or topic, not more then one.');
         }
         /*
-          if (empty($this->data)) {
-          throw new NotificationException('Data should not be empty for a Data Notification.');
-          }
-         */
+        if (empty($this->data)) {
+            throw new NotificationException('Data should not be empty for a Data Notification.');
+        }
+        */
         $request = [];
 
         if (!empty($this->recipients)) {
@@ -226,18 +236,17 @@ class Notification implements Request {
         $request['notification']['color'] = $this->color;
         $request['notification']['tag'] = $this->tag;
         $request['notification']['subtitle'] = $this->subtitle;
-        if ($this->badge > 0) {
+        if ($this->badge>0) {
             $request['notification']['badge'] = $this->badge;
         }
 
         if (!empty($this->click_action)) {
             $request['click_action'] = $this->click_action;
         }
-
+        
         if (!empty($this->data)) {
             $request['data'] = $this->data;
         }
-        return $request;
+        return $request; 
     }
-
 }

--- a/tests/PushTests/NotificationTest.php
+++ b/tests/PushTests/NotificationTest.php
@@ -459,10 +459,9 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
         $notification
             ->setTitle('Test title')
             ->addRecipient('device')
-            ->setClickAction('MAIN_ACTIVITY')
             ->addData('key', 'value');
 
-        $notification->setIcon('my icon');
+        $notification->setClickAction('MAIN_ACTIVITY');
 
         $expected = [
             'to' => 'device',
@@ -470,7 +469,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'title' => 'Test title',
                 'body'  => '',
                 'sound'  => '',
-                'icon'  => 'my icon',
+                'icon'  => '',
                 'color'  => '',
                 'tag'  => '',
                 'subtitle'  => '',

--- a/tests/PushTests/NotificationTest.php
+++ b/tests/PushTests/NotificationTest.php
@@ -452,4 +452,35 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected, $notification->getBody());
     }
 
+    /** @test */
+    public function it_generates_a_correct_notification_object_click_action()
+    {
+        $notification = new \Fcm\Push\Notification();
+        $notification
+            ->setTitle('Test title')
+            ->addRecipient('device')
+            ->setClickAction('MAIN_ACTIVITY')
+            ->addData('key', 'value');
+
+        $notification->setIcon('my icon');
+
+        $expected = [
+            'to' => 'device',
+            'notification' => [
+                'title' => 'Test title',
+                'body'  => '',
+                'sound'  => '',
+                'icon'  => 'my icon',
+                'color'  => '',
+                'tag'  => '',
+                'subtitle'  => '',
+                'click_action' => 'MAIN_ACTIVITY'
+            ],
+            'data' => [
+                'key' => 'value',
+            ],
+        ];
+        $this->assertSame($expected, $notification->getBody());
+    }
+
 }


### PR DESCRIPTION
i have added click_action parameter, which is required by ionic [FCM](https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated) plugin to handle the push when app is in the background mode. Although click_action parameter is optional, you can use as per your requirement.

please merge it as soon as possible so that we can use it in our projects
thanks to all the contributors for such an amazing library