### PR TITLE
Initial Laravel support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 
 install:
   - travis_retry composer install --no-interaction --no-suggest
+  - travis_retry composer require --no-interaction illuminate/support:^6.0 vlucas/phpdotenv:^3.3
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,15 @@
         "phpunit/phpunit": "^6.5",
         "mockery/mockery": "^1.0",
         "php-coveralls/php-coveralls": "^2.3"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Fcm\\Laravel\\FcmServiceProvider"
+            ]
+        }
+    },
+    "suggest": {
+        "laravel/framework": "Required to use Laravel (^6.0)."
     }
 }

--- a/src/FcmClient.php
+++ b/src/FcmClient.php
@@ -108,6 +108,10 @@ class FcmClient
         // and concatinate it back together.
         $group = array_slice($camelCaseSplit, 0, -1);
         $group = ucwords(implode('', $group));
+        
+        if ($group == 'Laravel') {
+            throw new FcmClientException('Invalid magic method called: cannot instantiate Laravel classes');
+        }
 
         // The classname is always the last item in the group name.
         $class = ucwords(end($camelCaseSplit));

--- a/src/Laravel/Fcm.php
+++ b/src/Laravel/Fcm.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Fcm\Laravel;
+
+use Fcm\FcmClient;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static array send(\Fcm\Request $request)
+ */
+class Fcm extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return FcmClient::class;
+    }
+}

--- a/src/Laravel/FcmServiceProvider.php
+++ b/src/Laravel/FcmServiceProvider.php
@@ -12,7 +12,7 @@ class FcmServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/stubs/config.php' => config_path('php-fcm.php'),
+                __DIR__.'/stubs/config.php' => $this->app->configPath('php-fcm.php'),
             ], 'php-fcm');
         }
     }
@@ -21,12 +21,14 @@ class FcmServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         $this->mergeConfigFrom(__DIR__.'/stubs/config.php', 'php-fcm');
 
-        $this->app->singleton(FcmClient::class, function () {
+        $this->app->singleton(FcmClient::class, function ($app) {
+            $config = $app->make('config');
+
             return new FcmClient(
-                config('php-fcm.key'), 
-                config('php-fcm.sender_id'),
+                $config->get('php-fcm.key'),
+                $config->get('php-fcm.sender_id'),
                 [
-                    'http_errors' => config('php-fcm.http_errors'),
+                    'http_errors' => $config->get('php-fcm.http_errors'),
                 ]
             );
         });

--- a/src/Laravel/FcmServiceProvider.php
+++ b/src/Laravel/FcmServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Fcm\Laravel;
+
+use Fcm\FcmClient;
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
+
+class FcmServiceProvider extends ServiceProvider implements DeferrableProvider
+{
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/stubs/config.php' => config_path('php-fcm.php'),
+            ], 'php-fcm');
+        }
+    }
+
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/stubs/config.php', 'php-fcm');
+
+        $this->app->singleton(FcmClient::class, function () {
+            return new FcmClient(
+                config('php-fcm.key'), 
+                config('php-fcm.sender_id'),
+                [
+                    'http_errors' => config('php-fcm.http_errors'),
+                ]
+            );
+        });
+    }
+
+    public function provides(): array
+    {
+        return [FcmClient::class];
+    }
+}

--- a/src/Laravel/stubs/config.php
+++ b/src/Laravel/stubs/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'key' => env('FCM_API_KEY'),
+    'sender_id' => env('FCM_SENDER_ID'),
+    'http_errors' => false,
+];


### PR DESCRIPTION
Hi,
Following issue #42, this PR allows an optionnal and simple Laravel support.

It offers a out of the box Laravel compatibility, you'll just have to add the following variables to your `.env` file:
```env
FCM_API_KEY=
FCM_SENDER_ID=
```

You can use the facade:
```php
use Fcm\Laravel\Fcm;
use Fcm\Push\Notification;

Fcm::send(
  (new Notification())
    ->setTitle('My title')
    ->setBody('My body')
    ->setClickAction('OPEN_ACTIVITY_1')
    ->addData('url', url())
    ->addRecipient('my-device-token')
);
```

You can also use the dependencies injection (controllers, jobs, `app(FcmClient::class)` helper...):

```php
use Fcm\FcmClient;
use Fcm\Push\Notification;

class MyClass
{
    public function myMethodWithDependenciesInjection(FcmClient $client)
    {
        $client->send(
          (new Notification())
            ->setTitle('My title')
            ->setBody('My body')
            ->setClickAction('OPEN_ACTIVITY_1')
            ->addData('url', url())
            ->addTopic('my-topic')
        );
    }
}
```

As it's optionnal, I chose to put everything related to Laravel in a subfolder, even the config file.
There are no documentations yet.

Thanks