### PR TITLE
Some simplifications and code polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,27 @@ Before the first time you run them, you may need to run:
 composer install
 ```
 
+## Windows TESTING
+For local Windows Testing, you will need to install xdebug and add
+```php.ini
+zend_extension=xdebug
+xdebug.mode=coverage
+```
+
+and set composer.json scripts line to:
+```
+    "scripts": {
+        "test": ["vendor/bin/phpunit -c phpunit.dist.xml"]
+    },
+```
+
+## xUX TESTING:
+For local xUX or online github/codeforce testing, in composer.json set scripts line to:
+```
+    "scripts": {
+        "test": ["XDEBUG_MODE=coverage vendor/bin/phpunit -c phpunit.dist.xml"]
+    },
+```
+
 ## License
 [MIT](LICENSE.md)

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "php-coveralls/php-coveralls": "^2.5"
     },
     "scripts": {
-        "test": ["XDEBUG_MODE=coverage vendor/bin/phpunit -c phpunit.dist.xml"]
+        "test": ["vendor/bin/phpunit -c phpunit.dist.xml"]
+    },
+    "scripts-descriptions": {
+        "test" : "Set PHP.ini xdebug.mode=coverage (windows) OR set 'test':['XMODE_DEBUG=coverage vendor/bin/phpunit ...'] (linux)"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require": {
         "php": ">= 7.3",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1a078978c6b9fe5428cf2a52e88c3ef",
+    "content-hash": "84ee229d9bac575ac6783a156cb34786",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.5.0",
+            "version": "7.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba"
+                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba",
-                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
+                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.9 || ^2.4",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
+                "guzzlehttp/psr7": "^2.7.0",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -32,10 +32,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "php-http/client-integration-tests": "^3.0",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -48,9 +49,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -116,7 +114,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.5.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
             },
             "funding": [
                 {
@@ -132,38 +130,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T15:39:27+00:00"
+            "time": "2024-07-24T11:22:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
+                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Promise\\": "src/"
                 }
@@ -200,7 +197,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/2.0.3"
             },
             "funding": [
                 {
@@ -216,26 +213,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2024-07-18T10:29:17+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379"
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/69568e4293f4fa993f3b0e51c9723e1e17c41379",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
@@ -243,9 +240,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -255,9 +252,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -319,7 +313,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
             },
             "funding": [
                 {
@@ -335,25 +329,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:45:39+00:00"
+            "time": "2024-07-18T11:15:46+00:00"
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -373,7 +367,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -385,27 +379,27 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
+                "source": "https://github.com/php-fig/http-client"
             },
-            "time": "2020-06-29T06:28:15+00:00"
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -425,10 +419,10 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -440,31 +434,31 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -479,7 +473,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -493,9 +487,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -543,16 +537,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.1.1",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918"
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918",
-                "reference": "07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
                 "shasum": ""
             },
             "require": {
@@ -561,7 +555,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -590,7 +584,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -606,36 +600,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T11:15:52+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -662,7 +656,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -678,7 +672,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -733,38 +727,38 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.5.1",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.3"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -775,12 +769,20 @@
                 {
                     "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
                 },
                 {
                     "name": "Dave Marshall",
                     "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
                 }
             ],
             "description": "Mockery is a simple yet flexible PHP mock object framework",
@@ -798,23 +800,26 @@
                 "testing"
             ],
             "support": {
+                "docs": "https://docs.mockery.io/",
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.5.1"
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
             },
-            "time": "2022-09-07T15:32:08+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -822,11 +827,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -852,7 +858,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -860,29 +866,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -890,7 +898,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -914,26 +922,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2022-09-04T07:30:47+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -974,9 +983,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -1031,28 +1046,28 @@
         },
         {
             "name": "php-coveralls/php-coveralls",
-            "version": "v2.5.3",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-coveralls/php-coveralls.git",
-                "reference": "9d8243bbf0e053333692857c98fab7cfba0d60a9"
+                "reference": "b36fa4394e519dafaddc04ae03976bc65a25ba15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/9d8243bbf0e053333692857c98fab7cfba0d60a9",
-                "reference": "9d8243bbf0e053333692857c98fab7cfba0d60a9",
+                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/b36fa4394e519dafaddc04ae03976bc65a25ba15",
+                "reference": "b36fa4394e519dafaddc04ae03976bc65a25ba15",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "guzzlehttp/guzzle": "^6.0 || ^7.0",
-                "php": "^5.5 || ^7.0 || ^8.0",
+                "php": "^7.0 || ^8.0",
                 "psr/log": "^1.0 || ^2.0",
-                "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-                "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-                "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-                "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+                "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0 || >=8.0 <8.5.29 || >=9.0 <9.5.23",
@@ -1108,50 +1123,50 @@
             ],
             "support": {
                 "issues": "https://github.com/php-coveralls/php-coveralls/issues",
-                "source": "https://github.com/php-coveralls/php-coveralls/tree/v2.5.3"
+                "source": "https://github.com/php-coveralls/php-coveralls/tree/v2.7.0"
             },
-            "time": "2022-09-12T20:47:09+00:00"
+            "time": "2023-11-22T10:21:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.17",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1179,7 +1194,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1187,7 +1203,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-30T12:24:04+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1432,50 +1448,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.25",
+            "version": "9.6.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1483,7 +1499,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1514,7 +1530,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
             },
             "funding": [
                 {
@@ -1530,7 +1547,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-25T03:44:45+00:00"
+            "time": "2024-07-10T11:45:39+00:00"
         },
         {
             "name": "psr/container",
@@ -1637,16 +1654,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -1681,7 +1698,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1689,7 +1706,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1878,20 +1895,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1923,7 +1940,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1931,20 +1948,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -1989,7 +2006,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1997,20 +2014,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -2052,7 +2069,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2060,20 +2077,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -2129,7 +2146,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2137,20 +2154,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -2193,7 +2210,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -2201,24 +2218,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -2250,7 +2267,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -2258,7 +2275,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2374,16 +2391,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -2422,10 +2439,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2433,20 +2450,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -2458,7 +2475,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2479,8 +2496,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -2488,20 +2504,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -2536,7 +2552,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -2544,7 +2560,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2601,36 +2617,34 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.1.3",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "a0645dc585d378b73c01115dd7ab9348f7d40c85"
+                "reference": "2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/a0645dc585d378b73c01115dd7ab9348f7d40c85",
-                "reference": "a0645dc585d378b73c01115dd7ab9348f7d40c85",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2",
+                "reference": "2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/filesystem": "^5.4|^6.0",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/finder": "<5.4"
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/messenger": "^5.4|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/yaml": "To use the yaml reference dumper"
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -2658,7 +2672,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.1.3"
+                "source": "https://github.com/symfony/config/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2674,53 +2688,50 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-20T15:00:40+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.4",
+            "version": "v7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7fccea8728aa2d431a6725b02b3ce759049fc84d"
+                "reference": "1eed7af6961d763e7832e874d7f9b21c3ea9c111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7fccea8728aa2d431a6725b02b3ce759049fc84d",
-                "reference": "7fccea8728aa2d431a6725b02b3ce759049fc84d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1eed7af6961d763e7832e874d7f9b21c3ea9c111",
+                "reference": "1eed7af6961d763e7832e874d7f9b21c3ea9c111",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.2",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.4|^6.0"
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -2749,12 +2760,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.4"
+                "source": "https://github.com/symfony/console/tree/v7.1.4"
             },
             "funding": [
                 {
@@ -2770,26 +2781,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-26T10:32:31+00:00"
+            "time": "2024-08-15T22:48:53+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.1.4",
+            "version": "v7.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3f39c04d2630c34019907b02f85672dac99f8659"
+                "reference": "92a91985250c251de9b947a14bb2c9390b1a562c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3f39c04d2630c34019907b02f85672dac99f8659",
-                "reference": "3f39c04d2630c34019907b02f85672dac99f8659",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/92a91985250c251de9b947a14bb2c9390b1a562c",
+                "reference": "92a91985250c251de9b947a14bb2c9390b1a562c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -2817,7 +2831,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.1.4"
+                "source": "https://github.com/symfony/filesystem/tree/v7.1.2"
             },
             "funding": [
                 {
@@ -2833,20 +2847,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-02T16:17:38+00:00"
+            "time": "2024-06-28T10:03:55+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.26.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
                 "shasum": ""
             },
             "require": {
@@ -2860,9 +2874,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2899,7 +2910,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -2915,20 +2926,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.26.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
-                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
                 "shasum": ""
             },
             "require": {
@@ -2939,9 +2950,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2980,7 +2988,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -2996,20 +3004,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.26.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
                 "shasum": ""
             },
             "require": {
@@ -3020,9 +3028,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3064,7 +3069,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -3080,20 +3085,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.26.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
                 "shasum": ""
             },
             "require": {
@@ -3107,9 +3112,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.26-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3147,7 +3149,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -3163,36 +3165,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.1.1",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239"
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/925e713fe8fcacf6bc05e936edd8dd5441a21239",
-                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
             },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3232,7 +3232,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.1.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -3248,25 +3248,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:18:58+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v6.1.0",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "77dedae82ce2a26e2e9b481855473fc3b3e4e54d"
+                "reference": "5b75bb1ac2ba1b9d05c47fc4b3046a625377d23d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/77dedae82ce2a26e2e9b481855473fc3b3e4e54d",
-                "reference": "77dedae82ce2a26e2e9b481855473fc3b3e4e54d",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5b75bb1ac2ba1b9d05c47fc4b3046a625377d23d",
+                "reference": "5b75bb1ac2ba1b9d05c47fc4b3046a625377d23d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/service-contracts": "^1|^2|^3"
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
             "autoload": {
@@ -3294,7 +3294,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v6.1.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3310,37 +3310,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T11:15:52+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.1.4",
+            "version": "v7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "290972cad7b364e3befaa74ba0ec729800fb161c"
+                "reference": "6cd670a6d968eaeb1c77c2e76091c45c56bc367b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/290972cad7b364e3befaa74ba0ec729800fb161c",
-                "reference": "290972cad7b364e3befaa74ba0ec729800fb161c",
+                "url": "https://api.github.com/repos/symfony/string/zipball/6cd670a6d968eaeb1c77c2e76091c45c56bc367b",
+                "reference": "6cd670a6d968eaeb1c77c2e76091c45c56bc367b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/translation-contracts": "^2.0|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -3379,7 +3381,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.1.4"
+                "source": "https://github.com/symfony/string/tree/v7.1.4"
             },
             "funding": [
                 {
@@ -3395,34 +3397,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-12T18:05:43+00:00"
+            "time": "2024-08-12T09:59:40+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.1.4",
+            "version": "v7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "86ee4d8fa594ed45e40d86eedfda1bcb66c8d919"
+                "reference": "92e080b851c1c655c786a2da77f188f2dccd0f4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/86ee4d8fa594ed45e40d86eedfda1bcb66c8d919",
-                "reference": "86ee4d8fa594ed45e40d86eedfda1bcb66c8d919",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/92e080b851c1c655c786a2da77f188f2dccd0f4b",
+                "reference": "92e080b851c1c655c786a2da77f188f2dccd0f4b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.4"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^6.4|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -3453,7 +3452,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.1.4"
+                "source": "https://github.com/symfony/yaml/tree/v7.1.4"
             },
             "funding": [
                 {
@@ -3469,20 +3468,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-02T16:17:38+00:00"
+            "time": "2024-08-12T09:59:40+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -3511,7 +3510,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -3519,7 +3518,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
@@ -3528,8 +3527,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 7.2"
+        "php": ">= 7.3",
+        "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Device/Info.php
+++ b/src/Device/Info.php
@@ -43,7 +43,7 @@ class Info implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         return [];
     }

--- a/src/Device/Info.php
+++ b/src/Device/Info.php
@@ -31,7 +31,7 @@ class Info implements Request
      */
     public function getUrl(): string
     {
-        $url = "https://iid.googleapis.com/iid/info/{$this->deviceId}";
+        $url = "https://iid.googleapis.com/iid/info/$this->deviceId";
 
         if ($this->details) {
             $url .= '?details=true';

--- a/src/DeviceGroup/Create.php
+++ b/src/DeviceGroup/Create.php
@@ -29,7 +29,7 @@ class Create implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         return [
             'operation' => 'create',

--- a/src/DeviceGroup/Remove.php
+++ b/src/DeviceGroup/Remove.php
@@ -36,7 +36,7 @@ class Remove implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         return [
             'operation' => 'remove',

--- a/src/DeviceGroup/Update.php
+++ b/src/DeviceGroup/Update.php
@@ -36,7 +36,7 @@ class Update implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         return [
             'operation' => 'add',

--- a/src/FcmClient.php
+++ b/src/FcmClient.php
@@ -5,6 +5,7 @@ namespace Fcm;
 use Fcm\Device\Info;
 use Fcm\Exception\FcmClientException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use ReflectionClass;
 
 /**
@@ -69,8 +70,8 @@ class FcmClient
 
     /**
      * @param Request $request
-     *
-     * @return array
+     * @return array The response body received from the FCM API, as an associative array.
+     * @throws FcmClientException When the sending failed.
      */
     public function send(Request $request): array
     {

--- a/src/FcmClient.php
+++ b/src/FcmClient.php
@@ -4,6 +4,7 @@ namespace Fcm;
 
 use Fcm\Device\Info;
 use Fcm\Exception\FcmClientException;
+use Fcm\Exception\NotificationException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use ReflectionClass;
@@ -71,6 +72,7 @@ class FcmClient
     /**
      * @param Request $request
      * @return array The response body received from the FCM API, as an associative array.
+     * @throws NotificationException When the given request isn't valid.
      * @throws FcmClientException When the sending failed.
      */
     public function send(Request $request): array
@@ -84,7 +86,7 @@ class FcmClient
         // Create and send the request.
         try {
             $response = $client->post($url, [
-                'json' => $request->getBody()
+                'json' => $request->buildJsonBody()
             ]);
         } catch (GuzzleException $e) {
             throw new FcmClientException('Failed to Connect: '.$e->getMessage());

--- a/src/Push/Data.php
+++ b/src/Push/Data.php
@@ -27,7 +27,7 @@ class Data implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         if (empty($this->data)) {
             throw new NotificationException('Data should not be empty for a Data Notification.');

--- a/src/Push/Data.php
+++ b/src/Push/Data.php
@@ -33,40 +33,6 @@ class Data implements Request
             throw new NotificationException('Data should not be empty for a Data Notification.');
         }
 
-        if (empty($this->recipients) && empty($this->topics)) {
-            throw new NotificationException('Must minimaly specify a single recipient or topic.');
-        }
-
-        if (!empty($this->recipients) && !empty($this->topics)) {
-            throw new NotificationException('Must either specify a recipient or topic, not more then one.');
-        }
-
-        $request = [];
-
-        if (!empty($this->recipients)) {
-            if (\count($this->recipients) === 1) {
-                $request['to'] = current($this->recipients);
-            } else {
-                $request['registration_ids'] = $this->recipients;
-            }
-        }
-
-        if (!empty($this->topics)) {
-            $request['condition'] = array_reduce($this->topics, function ($carry, string $topic) {
-                $topicSyntax = "'%s' in topics";
-
-                if (end($this->topics) === $topic) {
-                    return $carry .= sprintf($topicSyntax, $topic);
-                }
-
-                return $carry .= sprintf($topicSyntax, $topic) . '||';
-            });
-        }
-
-        if (!empty($this->data)) {
-            $request['data'] = $this->data;
-        }
-
-        return $request;
+        return $this->buildJsonPushBody();
     }
 }

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -2,7 +2,6 @@
 
 namespace Fcm\Push;
 
-use Fcm\Exception\NotificationException;
 use Fcm\Request;
 
 class Notification implements Request
@@ -54,11 +53,6 @@ class Notification implements Request
      */
     private $click_action;
 
-    /**
-     * @param string $title
-     * @param string $body
-     * @param string $recipient
-     */
     public function __construct(string $title = '', string $body = '', string $recipient = '', string $sound = '', string $icon = '', string $color = '', int $badge = 0, string $tag = '', string $subtitle = '', array $data = [], string $click_action = '')
     {
         $this->title = $title;
@@ -144,7 +138,7 @@ class Notification implements Request
     }
 
     /**
-     * @param string badge
+     * @param int $badge
      *
      * @return $this
      */

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -7,8 +7,8 @@ use Fcm\Request;
 
 class Notification implements Request
 {
-    use Push ;
-    
+    use Push;
+
     /**
      * @var string
      */
@@ -28,7 +28,7 @@ class Notification implements Request
      * @var string
      */
     private $icon;
-    
+
     /**
      * @var string
      */
@@ -37,8 +37,8 @@ class Notification implements Request
     /**
      * @var string
      */
-    private $tag;    
-    
+    private $tag;
+
     /**
      * @var string
      */
@@ -53,7 +53,7 @@ class Notification implements Request
      * @var string
      */
     private $click_action;
-    
+
     /**
      * @param string $title
      * @param string $body
@@ -73,11 +73,11 @@ class Notification implements Request
         if (!empty($click_action)) {
             $this->click_action = $click_action;
         }
-        
+
         if (!empty($data)) {
             $this->data = $data;
-        } 
-        
+        }
+
         if (!empty($recipient)) {
             $this->addRecipient($recipient);
         }
@@ -106,7 +106,7 @@ class Notification implements Request
 
         return $this;
     }
-    
+
     /**
      * @param string $sound
      *
@@ -117,8 +117,8 @@ class Notification implements Request
         $this->sound = $sound;
 
         return $this;
-    } 
-    
+    }
+
     /**
      * @param string $icon
      *
@@ -142,7 +142,7 @@ class Notification implements Request
 
         return $this;
     }
-    
+
     /**
      * @param string badge
      *
@@ -154,7 +154,7 @@ class Notification implements Request
 
         return $this;
     }
-    
+
     /**
      * @param string $tag
      *
@@ -184,7 +184,8 @@ class Notification implements Request
      *
      * @return $this
      */
-    public function setClickAction(string $click_action): self {
+    public function setClickAction(string $click_action): self
+    {
         $this->click_action = $click_action;
 
         return $this;
@@ -204,14 +205,14 @@ class Notification implements Request
         $request['notification']['color'] = $this->color;
         $request['notification']['tag'] = $this->tag;
         $request['notification']['subtitle'] = $this->subtitle;
-        if ($this->badge>0) {
+        if ($this->badge > 0) {
             $request['notification']['badge'] = $this->badge;
         }
 
         if (!empty($this->click_action)) {
             $request['notification']['click_action'] = $this->click_action;
         }
-        
+
         return $request;
     }
 }

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -194,7 +194,7 @@ class Notification implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         $request = $this->buildJsonPushBody();
 

--- a/src/Push/Notification.php
+++ b/src/Push/Notification.php
@@ -195,39 +195,7 @@ class Notification implements Request
      */
     public function getBody(): array
     {
-        if (empty($this->recipients) && empty($this->topics)) {
-            throw new NotificationException('Must minimaly specify a single recipient or topic.');
-        }
-
-        if (!empty($this->recipients) && !empty($this->topics)) {
-            throw new NotificationException('Must either specify a recipient or topic, not more then one.');
-        }
-        /*
-        if (empty($this->data)) {
-            throw new NotificationException('Data should not be empty for a Data Notification.');
-        }
-        */
-        $request = [];
-
-        if (!empty($this->recipients)) {
-            if (\count($this->recipients) === 1) {
-                $request['to'] = current($this->recipients);
-            } else {
-                $request['registration_ids'] = $this->recipients;
-            }
-        }
-
-        if (!empty($this->topics)) {
-            $request['condition'] = array_reduce($this->topics, function ($carry, string $topic) {
-                $topicSyntax = "'%s' in topics";
-
-                if (end($this->topics) === $topic) {
-                    return $carry .= sprintf($topicSyntax, $topic);
-                }
-
-                return $carry .= sprintf($topicSyntax, $topic) . '||';
-            });
-        }
+        $request = $this->buildJsonPushBody();
 
         $request['notification']['title'] = $this->title;
         $request['notification']['body'] = $this->body;
@@ -244,9 +212,6 @@ class Notification implements Request
             $request['notification']['click_action'] = $this->click_action;
         }
         
-        if (!empty($this->data)) {
-            $request['data'] = $this->data;
-        }
-        return $request; 
+        return $request;
     }
 }

--- a/src/Push/Push.php
+++ b/src/Push/Push.php
@@ -58,10 +58,9 @@ trait Push
     }
 
     /**
-     * @param string $name
-     * @param mixed $value
-     *
-     * @return Push
+     * @param $dataArray
+     * @return self
+     * @throws NotificationException
      */
     public function addDataArray($dataArray): self
     {

--- a/src/Push/Push.php
+++ b/src/Push/Push.php
@@ -94,4 +94,47 @@ trait Push
     {
         return 'https://fcm.googleapis.com/fcm/send';
     }
+
+    /**
+     * @return array JSON body with only the fields of the Push trait.
+     * @throws NotificationException When this object isn't valid.
+     */
+    protected function buildJsonPushBody(): array
+    {
+        if (empty($this->recipients) && empty($this->topics)) {
+            throw new NotificationException('Must minimaly specify a single recipient or topic.');
+        }
+
+        if (!empty($this->recipients) && !empty($this->topics)) {
+            throw new NotificationException('Must either specify a recipient or topic, not more then one.');
+        }
+
+        $request = [];
+
+        if (!empty($this->recipients)) {
+            if (\count($this->recipients) === 1) {
+                $request['to'] = current($this->recipients);
+            } else {
+                $request['registration_ids'] = $this->recipients;
+            }
+        }
+
+        if (!empty($this->topics)) {
+            $request['condition'] = array_reduce($this->topics, function ($carry, string $topic) {
+                $topicSyntax = "'%s' in topics";
+
+                if (end($this->topics) === $topic) {
+                    return $carry .= sprintf($topicSyntax, $topic);
+                }
+
+                return $carry .= sprintf($topicSyntax, $topic) . '||';
+            });
+        }
+
+        if (!empty($this->data)) {
+            $request['data'] = $this->data;
+        }
+
+        return $request;
+    }
 }

--- a/src/Push/Push.php
+++ b/src/Push/Push.php
@@ -23,17 +23,16 @@ trait Push
 
     /**
      * @param string|array $iidToken
-     *
      * @return self
      */
     public function addRecipient($iidToken): self
     {
         if (\is_string($iidToken)) {
             $this->recipients[] = $iidToken;
-        }
-
-        if (\is_array($iidToken)) {
-            $this->recipients = array_merge($this->recipients, $iidToken);
+        } else if (\is_array($iidToken)) {
+            $this->recipients = array_merge($this->recipients, array_values($iidToken));
+        } else {
+            throw new \InvalidArgumentException('iidToken must be a string or an array of strings');
         }
 
         return $this;
@@ -111,7 +110,7 @@ trait Push
 
         if (!empty($this->recipients)) {
             if (\count($this->recipients) === 1) {
-                $request['to'] = current($this->recipients);
+                $request['to'] = $this->recipients[0];
             } else {
                 $request['registration_ids'] = $this->recipients;
             }

--- a/src/Push/Push.php
+++ b/src/Push/Push.php
@@ -57,7 +57,7 @@ trait Push
 
         return $this;
     }
-    
+
     /**
      * @param string $name
      * @param mixed $value
@@ -67,12 +67,12 @@ trait Push
     public function addDataArray($dataArray): self
     {
         if (is_array($dataArray)) {
-            $this->data = array_merge($this->data, $dataArray) ;
+            $this->data = array_merge($this->data, $dataArray);
         } else {
-            throw new NotificationException('Data must be an asscoiative array of ("key" => "value") pairs.');        
+            throw new NotificationException('Data must be an asscoiative array of ("key" => "value") pairs.');
         }
         return $this;
-    }    
+    }
 
     /**
      * @param string $name

--- a/src/Push/Push.php
+++ b/src/Push/Push.php
@@ -4,7 +4,6 @@ namespace Fcm\Push;
 
 use Fcm\Exception\NotificationException;
 
-
 trait Push
 {
     /**
@@ -102,11 +101,11 @@ trait Push
     protected function buildJsonPushBody(): array
     {
         if (empty($this->recipients) && empty($this->topics)) {
-            throw new NotificationException('Must minimaly specify a single recipient or topic.');
+            throw new NotificationException('Must specify at least one recipient or topic.');
         }
 
         if (!empty($this->recipients) && !empty($this->topics)) {
-            throw new NotificationException('Must either specify a recipient or topic, not more then one.');
+            throw new NotificationException('Must not specify both a recipient and a topic.');
         }
 
         $request = [];

--- a/src/Push/Push.php
+++ b/src/Push/Push.php
@@ -117,15 +117,9 @@ trait Push
         }
 
         if (!empty($this->topics)) {
-            $request['condition'] = array_reduce($this->topics, function ($carry, string $topic) {
-                $topicSyntax = "'%s' in topics";
-
-                if (end($this->topics) === $topic) {
-                    return $carry .= sprintf($topicSyntax, $topic);
-                }
-
-                return $carry .= sprintf($topicSyntax, $topic) . '||';
-            });
+            $request['condition'] = implode('||', array_map(function (string $topic) {
+                return sprintf("'%s' in topics", $topic);
+            }, $this->topics));
         }
 
         if (!empty($this->data)) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -2,6 +2,8 @@
 
 namespace Fcm;
 
+use Fcm\Exception\NotificationException;
+
 interface Request
 {
     /**
@@ -10,7 +12,9 @@ interface Request
     public function getUrl(): string;
 
     /**
-     * @return array
+     * You should not need to call this function. Instead pass the request object into {@link FcmClient::send()}.
+     * @return array An associative array with the shape of a JSON request expected by the FCM API.
+     * @throws NotificationException When this object isn't valid, so a request can't be built.
      */
-    public function getBody(): array;
+    public function buildJsonBody(): array;
 }

--- a/src/Topic/Subscribe.php
+++ b/src/Topic/Subscribe.php
@@ -2,6 +2,7 @@
 
 namespace Fcm\Topic;
 
+use Fcm\Exception\TopicException;
 use Fcm\Request;
 
 class Subscribe implements Request
@@ -16,6 +17,7 @@ class Subscribe implements Request
     /**
      * @param string $topicName
      * @param string $deviceId
+     * @throws TopicException When the $deviceId is empty.
      */
     public function __construct(string $topicName, string $deviceId = '')
     {
@@ -40,7 +42,7 @@ class Subscribe implements Request
     public function buildJsonBody(): array
     {
         return [
-            'to' => "/topics/{$this->topicName}",
+            'to' => "/topics/$this->topicName",
             'registration_tokens' => $this->devices,
         ];
     }

--- a/src/Topic/Subscribe.php
+++ b/src/Topic/Subscribe.php
@@ -37,7 +37,7 @@ class Subscribe implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         return [
             'to' => "/topics/{$this->topicName}",

--- a/src/Topic/Topic.php
+++ b/src/Topic/Topic.php
@@ -15,6 +15,7 @@ trait Topic
      * @param string|array $deviceId
      *
      * @return self
+     * @throws TopicException When the $deviceId is empty.
      */
     public function addDevice($deviceId): self
     {

--- a/src/Topic/Unsubscribe.php
+++ b/src/Topic/Unsubscribe.php
@@ -2,6 +2,7 @@
 
 namespace Fcm\Topic;
 
+use Fcm\Exception\TopicException;
 use Fcm\Request;
 
 class Unsubscribe implements Request
@@ -16,6 +17,7 @@ class Unsubscribe implements Request
     /**
      * @param string $topicName
      * @param string $deviceId
+     * @throws TopicException When the $deviceId is empty.
      */
     public function __construct(string $topicName, string $deviceId = '')
     {
@@ -40,7 +42,7 @@ class Unsubscribe implements Request
     public function buildJsonBody(): array
     {
         return [
-            'to' => "/topics/{$this->topicName}",
+            'to' => "/topics/$this->topicName",
             'registration_tokens' => $this->devices,
         ];
     }

--- a/src/Topic/Unsubscribe.php
+++ b/src/Topic/Unsubscribe.php
@@ -37,7 +37,7 @@ class Unsubscribe implements Request
     /**
      * @inheritdoc
      */
-    public function getBody(): array
+    public function buildJsonBody(): array
     {
         return [
             'to' => "/topics/{$this->topicName}",

--- a/tests/DeviceGroupTests/CreateTest.php
+++ b/tests/DeviceGroupTests/CreateTest.php
@@ -18,7 +18,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $create->getBody());
+        $this->assertSame($expected, $create->buildJsonBody());
         $this->assertSame('https://android.googleapis.com/gcm/notification', $create->getUrl());
     }
 
@@ -42,7 +42,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $create->getBody());
+        $this->assertSame($expected, $create->buildJsonBody());
     }
 
     /** @test */
@@ -60,6 +60,6 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $create->getBody());
+        $this->assertSame($expected, $create->buildJsonBody());
     }
 }

--- a/tests/DeviceGroupTests/RemoveTest.php
+++ b/tests/DeviceGroupTests/RemoveTest.php
@@ -19,7 +19,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $remove->getBody());
+        $this->assertSame($expected, $remove->buildJsonBody());
     }
 
     /** @test */
@@ -43,7 +43,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $remove->getBody());
+        $this->assertSame($expected, $remove->buildJsonBody());
     }
 
     /** @test */
@@ -66,6 +66,6 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $remove->getBody());
+        $this->assertSame($expected, $remove->buildJsonBody());
     }
 }

--- a/tests/DeviceGroupTests/UpdateTest.php
+++ b/tests/DeviceGroupTests/UpdateTest.php
@@ -19,7 +19,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $update->getBody());
+        $this->assertSame($expected, $update->buildJsonBody());
     }
 
     /** @test */
@@ -43,7 +43,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $update->getBody());
+        $this->assertSame($expected, $update->buildJsonBody());
     }
 
     /** @test */
@@ -66,6 +66,6 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertSame($expected, $update->getBody());
+        $this->assertSame($expected, $update->buildJsonBody());
     }
 }

--- a/tests/DeviceTests/InfoTest.php
+++ b/tests/DeviceTests/InfoTest.php
@@ -9,12 +9,12 @@ class InfoTest extends \PHPUnit\Framework\TestCase
     {
         $info = new \Fcm\Device\Info('device_id');
 
-        $this->assertSame([], $info->getBody());
+        $this->assertSame([], $info->buildJsonBody());
         $this->assertSame('https://iid.googleapis.com/iid/info/device_id', $info->getUrl());
 
         $info = new \Fcm\Device\Info('device_id_new', true);
 
-        $this->assertSame([], $info->getBody());
+        $this->assertSame([], $info->buildJsonBody());
         $this->assertSame('https://iid.googleapis.com/iid/info/device_id_new?details=true', $info->getUrl());
     }
 

--- a/tests/PushTests/DataTest.php
+++ b/tests/PushTests/DataTest.php
@@ -19,7 +19,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data->getBody());
+        $this->assertEquals($expected, $data->getBody());
     }
 
     /** @test */
@@ -77,7 +77,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data->getBody());
+        $this->assertEquals($expected, $data->getBody());
     }
 
     /** @test */
@@ -96,7 +96,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data->getBody());
+        $this->assertEquals($expected, $data->getBody());
     }
 
     /** @test */
@@ -118,7 +118,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data->getBody());
+        $this->assertEquals($expected, $data->getBody());
     }
 
     /** @test */
@@ -139,6 +139,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data->getBody());
+        $this->assertEquals($expected, $data->getBody());
     }
 }

--- a/tests/PushTests/DataTest.php
+++ b/tests/PushTests/DataTest.php
@@ -19,7 +19,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data->getBody());
+        $this->assertEquals($expected, $data->buildJsonBody());
     }
 
     /** @test */
@@ -30,7 +30,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $data = new \Fcm\Push\Data();
         $data->addData('key', 'value');
 
-        $data->getBody();
+        $data->buildJsonBody();
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ->addTopic('topic')
             ->addData('key', 'value');
 
-        $data->getBody();
+        $data->buildJsonBody();
     }
 
     /** @test */
@@ -54,7 +54,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Fcm\Exception\NotificationException::class);
         $data = new \Fcm\Push\Data();
 
-        $data->getBody();
+        $data->buildJsonBody();
     }
 
     /** @test */
@@ -77,7 +77,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data->getBody());
+        $this->assertEquals($expected, $data->buildJsonBody());
     }
 
     /** @test */
@@ -96,7 +96,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data->getBody());
+        $this->assertEquals($expected, $data->buildJsonBody());
     }
 
     /** @test */
@@ -118,7 +118,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data->getBody());
+        $this->assertEquals($expected, $data->buildJsonBody());
     }
 
     /** @test */
@@ -139,6 +139,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data->getBody());
+        $this->assertEquals($expected, $data->buildJsonBody());
     }
 }

--- a/tests/PushTests/DataTest.php
+++ b/tests/PushTests/DataTest.php
@@ -25,7 +25,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_not_have_no_recipients_or_topics()
     {
-        $this->expectExceptionMessage("Must minimaly specify a single recipient or topic.");
+        $this->expectExceptionMessage("Must specify at least one recipient or topic.");
         $this->expectException(\Fcm\Exception\NotificationException::class);
         $data = new \Fcm\Push\Data();
         $data->addData('key', 'value');
@@ -36,7 +36,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_not_have_a_recipient_and_topic()
     {
-        $this->expectExceptionMessage("Must either specify a recipient or topic, not more then one.");
+        $this->expectExceptionMessage("Must not specify both a recipient and a topic.");
         $this->expectException(\Fcm\Exception\NotificationException::class);
         $data = new \Fcm\Push\Data();
         $data

--- a/tests/PushTests/DataTest.php
+++ b/tests/PushTests/DataTest.php
@@ -135,7 +135,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             'to' => 'device_id',
             'data' => [
                 'sample' => 'example',
-                'my_name'  => 'john doe',
+                'my_name' => 'john doe',
             ],
         ];
 

--- a/tests/PushTests/NotificationTest.php
+++ b/tests/PushTests/NotificationTest.php
@@ -30,7 +30,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
         $this->assertSame('https://fcm.googleapis.com/fcm/send', $notification->getUrl());
     }
 
@@ -44,7 +44,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ->setTitle('Test title')
             ->setBody('A small body as an example');
 
-        $notification->getBody();
+        $notification->buildJsonBody();
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ->addRecipient('device')
             ->addTopic('topic');
 
-        $notification->getBody();
+        $notification->buildJsonBody();
     }
 
 
@@ -92,7 +92,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
     /** @test */
@@ -125,7 +125,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
     /** @test */
@@ -157,7 +157,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -182,7 +182,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -219,7 +219,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -234,7 +234,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ->addRecipient('device')
             ->addDataArray('array');
 
-        $notification->getBody();
+        $notification->buildJsonBody();
     }
 
 
@@ -281,7 +281,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -305,7 +305,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -335,7 +335,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -366,7 +366,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -396,7 +396,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -426,7 +426,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -456,7 +456,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -486,7 +486,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
     /** @test */
@@ -516,7 +516,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 
@@ -544,7 +544,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertEquals($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->buildJsonBody());
     }
 
 }

--- a/tests/PushTests/NotificationTest.php
+++ b/tests/PushTests/NotificationTest.php
@@ -37,7 +37,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_not_have_no_recipients_or_topics()
     {
-        $this->expectExceptionMessage("Must minimaly specify a single recipient or topic.");
+        $this->expectExceptionMessage("Must specify at least one recipient or topic.");
         $this->expectException(\Fcm\Exception\NotificationException::class);
         $notification = new \Fcm\Push\Notification();
         $notification
@@ -50,7 +50,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_not_have_a_recipient_and_topic()
     {
-        $this->expectExceptionMessage("Must either specify a recipient or topic, not more then one.");
+        $this->expectExceptionMessage("Must not specify both a recipient and a topic.");
         $this->expectException(\Fcm\Exception\NotificationException::class);
         $notification = new \Fcm\Push\Notification();
         $notification

--- a/tests/PushTests/NotificationTest.php
+++ b/tests/PushTests/NotificationTest.php
@@ -18,12 +18,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device_1',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => 'A small body as an example',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => 'A small body as an example',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -80,12 +80,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -109,16 +109,16 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'condition' => "'news' in topics||'weather' in topics||'personal' in topics",
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
+                'body' => '',
             ],
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -143,12 +143,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -173,12 +173,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
         ];
 
@@ -195,22 +195,22 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ->addRecipient('device')
             ->addDataArray(
                 array(
-                    'key'=>'value',
-                    'name'=>'notification',
-                    'test'=>'data',
-                    )
-                );
+                    'key' => 'value',
+                    'name' => 'notification',
+                    'test' => 'data',
+                )
+            );
 
         $expected = [
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -247,37 +247,37 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ->addRecipient('device')
             ->addDataArray(
                 array(
-                    'i1'=>'the value of one',
-                    'i2'=>'the value of two',
-                    'i3'=>'the value of three',
-                    )
+                    'i1' => 'the value of one',
+                    'i2' => 'the value of two',
+                    'i3' => 'the value of three',
                 )
+            )
             ->addDataArray(
                 array(
-                    'i4'=>'the value of four',
-                    'i5'=>'the value of five',
-                    'i6'=>'the value of six',
-                    )
-                );
+                    'i4' => 'the value of four',
+                    'i5' => 'the value of five',
+                    'i6' => 'the value of six',
+                )
+            );
 
         $expected = [
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
-                'i1'=>'the value of one',
-                'i2'=>'the value of two',
-                'i3'=>'the value of three',
-                'i4'=>'the value of four',
-                'i5'=>'the value of five',
-                'i6'=>'the value of six',
+                'i1' => 'the value of one',
+                'i2' => 'the value of two',
+                'i3' => 'the value of three',
+                'i4' => 'the value of four',
+                'i5' => 'the value of five',
+                'i6' => 'the value of six',
             ],
         ];
 
@@ -296,12 +296,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device_id',
             'notification' => [
                 'title' => 'Sample title',
-                'body'  => 'Sample body',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => 'Sample body',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
         ];
 
@@ -324,12 +324,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => 'my sound',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => 'my sound',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -354,13 +354,13 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
-                'badge'  => 1,
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
+                'badge' => 1,
             ],
             'data' => [
                 'key' => 'value',
@@ -385,12 +385,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => 'my tag',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => 'my tag',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -415,12 +415,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => 'my subtitle',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => 'my subtitle',
             ],
             'data' => [
                 'key' => 'value',
@@ -428,7 +428,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
         ];
         $this->assertEquals($expected, $notification->getBody());
     }
-    
+
 
     /** @test */
     public function it_generates_a_correct_notification_object_setting_color()
@@ -445,12 +445,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => 'my color',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => 'my color',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -475,12 +475,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => 'my icon',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => 'my icon',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',
@@ -504,12 +504,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
                 'click_action' => 'MAIN_ACTIVITY'
             ],
             'data' => [
@@ -533,12 +533,12 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             'to' => 'device',
             'notification' => [
                 'title' => 'Test title',
-                'body'  => '',
-                'sound'  => '',
-                'icon'  => '',
-                'color'  => '',
-                'tag'  => '',
-                'subtitle'  => '',
+                'body' => '',
+                'sound' => '',
+                'icon' => '',
+                'color' => '',
+                'tag' => '',
+                'subtitle' => '',
             ],
             'data' => [
                 'key' => 'value',

--- a/tests/PushTests/NotificationTest.php
+++ b/tests/PushTests/NotificationTest.php
@@ -30,7 +30,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
         $this->assertSame('https://fcm.googleapis.com/fcm/send', $notification->getUrl());
     }
 
@@ -92,7 +92,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
     /** @test */
@@ -125,7 +125,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
     /** @test */
@@ -157,7 +157,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -182,7 +182,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -219,7 +219,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -281,7 +281,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -305,7 +305,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -335,7 +335,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -366,7 +366,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -396,7 +396,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -426,7 +426,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
     
 
@@ -456,7 +456,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -486,7 +486,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
     /** @test */
@@ -516,7 +516,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 
@@ -544,7 +544,7 @@ class NotificationTest extends \PHPUnit\Framework\TestCase
                 'key' => 'value',
             ],
         ];
-        $this->assertSame($expected, $notification->getBody());
+        $this->assertEquals($expected, $notification->getBody());
     }
 
 }

--- a/tests/TopicTests/SubscribeTest.php
+++ b/tests/TopicTests/SubscribeTest.php
@@ -17,7 +17,7 @@ class SubscribeTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $subscribe->getBody());
+        $this->assertSame($expected, $subscribe->buildJsonBody());
         $this->assertSame('https://iid.googleapis.com/iid/v1:batchAdd', $subscribe->getUrl());
     }
 
@@ -38,7 +38,7 @@ class SubscribeTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $subscribe->getBody());
+        $this->assertSame($expected, $subscribe->buildJsonBody());
     }
 
     /** @test */
@@ -64,6 +64,6 @@ class SubscribeTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $subscribe->getBody());
+        $this->assertSame($expected, $subscribe->buildJsonBody());
     }
 }

--- a/tests/TopicTests/UnsubscribeTest.php
+++ b/tests/TopicTests/UnsubscribeTest.php
@@ -17,7 +17,7 @@ class UnsubscribeTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $unsubscribe->getBody());
+        $this->assertSame($expected, $unsubscribe->buildJsonBody());
         $this->assertSame('https://iid.googleapis.com/iid/v1:batchRemove', $unsubscribe->getUrl());
     }
 
@@ -38,7 +38,7 @@ class UnsubscribeTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $unsubscribe->getBody());
+        $this->assertSame($expected, $unsubscribe->buildJsonBody());
     }
 
     /** @test */
@@ -64,6 +64,6 @@ class UnsubscribeTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertSame($expected, $unsubscribe->getBody());
+        $this->assertSame($expected, $unsubscribe->buildJsonBody());
     }
 }


### PR DESCRIPTION
See the individual commit messages and diffs.

Breaking changes:

* `ext-json` is now declared as a dependency. It was actually a dependency before, but now it's declared, which might break some builds.
* `Request::getBody()` was renamed to `Request::buildJsonBody()`. Most clients won't care, as they don't call this function.
* `FcmClient::send()` does not throw `GuzzleException` anymore, but now wraps it into `FcmClientException` (same exception type as when the server returns an error).